### PR TITLE
Add TabView navigation with Home, Favourites, and Settings views

### DIFF
--- a/PokemonTcg/BottomBar/BottomNavUI.swift
+++ b/PokemonTcg/BottomBar/BottomNavUI.swift
@@ -1,0 +1,32 @@
+//
+//  BottomNavUI.swift
+//  PokemonTcg
+//
+//  Created by Cláudio Costa on 24/06/2025.
+//
+
+import SwiftUI
+
+struct BottomNavUI: View {
+    var body: some View {
+        TabView{
+            ListUIView()
+                .tabItem{
+                    Label("",systemImage:"house.fill")
+                }
+            FavouriteUIView()
+                .tabItem{
+                    Label("",systemImage:"heart.fill")
+                }
+            
+            SettingsUIView()
+                .tabItem{
+                    Label("",systemImage:"gearshape.fill")
+                }
+        }
+    }
+}
+
+#Preview {
+    BottomNavUI()
+}

--- a/PokemonTcg/Favourites/FavouriteUIView.swift
+++ b/PokemonTcg/Favourites/FavouriteUIView.swift
@@ -1,5 +1,5 @@
 //
-//  ContentView.swift
+//  FavouriteUIView.swift
 //  PokemonTcg
 //
 //  Created by Cláudio Costa on 24/06/2025.
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct ContentView: View {
+struct FavouriteUIView: View {
     var body: some View {
-        BottomNavUI()
+        Text("Favourite")
     }
 }
 
 #Preview {
-    ContentView()
+    FavouriteUIView()
 }

--- a/PokemonTcg/Home/ListUIView.swift
+++ b/PokemonTcg/Home/ListUIView.swift
@@ -1,5 +1,5 @@
 //
-//  ContentView.swift
+//  ListUIView.swift
 //  PokemonTcg
 //
 //  Created by Cláudio Costa on 24/06/2025.
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct ContentView: View {
+struct ListUIView: View {
     var body: some View {
-        BottomNavUI()
+        Text("PokemonList")
     }
 }
 
 #Preview {
-    ContentView()
+    ListUIView()
 }

--- a/PokemonTcg/Settings/SettingsUIView.swift
+++ b/PokemonTcg/Settings/SettingsUIView.swift
@@ -1,5 +1,5 @@
 //
-//  ContentView.swift
+//  SettingsUIView.swift
 //  PokemonTcg
 //
 //  Created by Cláudio Costa on 24/06/2025.
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct ContentView: View {
+struct SettingsUIView: View {
     var body: some View {
-        BottomNavUI()
+        Text("Settings")
     }
 }
 
 #Preview {
-    ContentView()
+    SettingsUIView()
 }


### PR DESCRIPTION
This PR implements a TabView that enables navigation between three distinct screens as outlined in the exercise. Each screen is represented by its own SwiftUI view, and the tab bar includes appropriate system icons for clarity and usability.

Screens included:
    Home (ListUIView)
    Favourites (FavouriteUIView)
    Settings (SettingsUIView)
 